### PR TITLE
Decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Spartancoin
-Proof of concept of Bitcoin's proof-of-work with SHA-512
+Proof of concept of Bitcoin's proof-of-work with SHA-512.
+
+For public and private keys, Bitcoin uses SECP256K1 for its EC curve.
+
 
 ## Setup and Installation
 You need Python 3.7 or later.

--- a/src/spartancoin/transactions.py
+++ b/src/spartancoin/transactions.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from io import BytesIO
-from typing import cast, Collection
+from typing import cast, Sequence
 
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -291,8 +291,8 @@ class Transaction:
         list of outputs                   | varies
     """
 
-    senders: Collection[Sender]
-    receivers: Collection[Receiver]
+    senders: Sequence[Sender]
+    receivers: Sequence[Receiver]
 
     def __eq__(self, other):
         if not isinstance(other, Transaction):

--- a/src/spartancoin/transactions.py
+++ b/src/spartancoin/transactions.py
@@ -1,7 +1,6 @@
 """
-This module handles transactions
+This module handles transactions.
 
-Bitcoin uses ec.SECP256K1 for its EC curve.
 """
 
 from __future__ import annotations

--- a/src/spartancoin/transactions.py
+++ b/src/spartancoin/transactions.py
@@ -43,7 +43,17 @@ def encode_varint(i: int) -> bytes:
 
 
 def _assert_read(f: BytesIO, n: int) -> bytes:
-    """Read and assert length"""
+    """
+    Read and assert length is as expected
+
+    >>> f = BytesIO(b"01")
+    >>> _assert_read(f, 1)
+    b'0'
+    >>> _assert_read(f, 2)
+    Traceback (most recent call last):
+      ...
+    spartancoin.exceptions.DecodeError: Expecting length 2
+    """
     d = f.read(n)
     if len(d) != n:
         raise DecodeError(f"Expecting length {n:d}")

--- a/src/spartancoin/transactions.py
+++ b/src/spartancoin/transactions.py
@@ -284,6 +284,11 @@ class Transaction:
     senders: Collection[Sender]
     receivers: Collection[Receiver]
 
+    def __eq__(self, other):
+        if not isinstance(other, Transaction):
+            return NotImplemented
+        return self.senders == other.senders and self.receivers == other.receivers
+
     def encode(self) -> bytes:
         """Serialize the transaction"""
         return b"".join(

--- a/src/spartancoin/transactions.py
+++ b/src/spartancoin/transactions.py
@@ -288,7 +288,7 @@ class Transaction:
         """Serialize the transaction"""
         return b"".join(
             [
-                b"0001",  # version 1
+                b"\x01\x00\x00\x00",  # version 1 in little endian
                 encode_varint(len(self.senders)),
                 *[tx.encode() for tx in self.senders],
                 encode_varint(len(self.receivers)),

--- a/src/spartancoin/transactions.py
+++ b/src/spartancoin/transactions.py
@@ -1,6 +1,10 @@
 """
 This module handles transactions.
 
+The naming conventions for `decode` and `raw_decode` functions are that `decode`
+functions take `bytes` objects expecting a single object while `raw_decode`
+takes `BytesIO` objects take from the stream as they parse, possibly leaving
+extra characters in the stream.
 """
 
 from __future__ import annotations

--- a/src/spartancoin/transactions.py
+++ b/src/spartancoin/transactions.py
@@ -1,10 +1,11 @@
 """
 This module handles transactions.
 
-The naming conventions for `decode` and `raw_decode` functions are that `decode`
-functions take `bytes` objects expecting a single object while `raw_decode`
-takes `BytesIO` objects take from the stream as they parse, possibly leaving
-extra characters in the stream.
+The naming conventions for `decode` and `raw_decode` functions are that:
+- `decode` functions take `bytes` objects expecting a single object
+- `raw_decode` takes `BytesIO` objects may have extraneous data at the end
+  and will only take from the stream as much as they need to parse the next
+  object, leaving the extraneous characters in the stream
 """
 
 from __future__ import annotations

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -84,7 +84,7 @@ class TestVarInt:
         """
         Invalid encodings should raise.
         """
-        with pytest.raises(ValueError):
+        with pytest.raises(DecodeError):
             decode_varint(b)
 
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -16,6 +16,7 @@ from spartancoin.transactions import (
     encode_varint,
     Receiver,
     Sender,
+    Transaction,
 )
 
 
@@ -215,3 +216,44 @@ class TestRx:
         with pytest.raises(DecodeError) as excinfo:
             Receiver.decode(encoded[:-1])
         assert "Expecting length 88" in excinfo.value.args
+
+
+class TestTransaction:
+    """Test the `Transaction` class"""
+
+    @staticmethod
+    def test_encode_decode() -> None:
+        """Test decoding invalid representations raise"""
+        encoded = (
+            b"\x01\x00\x00\x00\x021234567890qwertyuiopasdfghjkl;zx\x03\x00\x00"
+            b"\x00\xa00F\x02!\x00\xaeY\x94\xd1\xd0\xc12g\xb1\xa9\xfb\x06\xe8"
+            b"E(\x15Aw\xedb\xde\x0bd\x06\xf7\x05\xbf7%aY,\x02!\x00\xb6."
+            b"\xe4d\"\xc1e1\x00\x17\x93\x98\xb5zt\xfa$3\xdc\xbd\x19l'G\xbf\xb5"
+            b"\xc7\xa26\t;\xd50V0\x10\x06\x07*\x86H\xce=\x02\x01\x06"
+            b"\x05+\x81\x04\x00\n\x03B\x00\x04N\x9a\xae\xd2G22\x82\xa6+"
+            b"\x18_W\xdfW9\xc4U\xc4 \x97e-9=\xa1\xb7\x0bQ\x97\x11sR\xadiR9\xa2"
+            b"\nu\xe4\xb6<\xc8\xb3\xe8\x01\x9d\x8e\x01\xc3\x0e\xb4\xa1"
+            b"t\xa2\xc8px\\4]\xb0{0987654321qwertyuiopasdfghjkl;zx\x03\x00"
+            b"\x00\x00\x9e0D\x02 eY\xb8P\x01\xf7\t\xb0w\xe4\xda}s\xaa1%\n"
+            b"(\x11\x95Xy\x1e\x99\x87\x0c\x10\x1d(#%\xf7\x02  \xb4a"
+            b"R\xc2\x98\x16\xf3\xf0\x16\x0f}\xb4\x91N\xc8\x87\x19\\\x06\xc6rk"
+            b"\xf0\th\x10\xbe\xe1x\xeb\xf80V0\x10\x06\x07*\x86H\xce="
+            b"\x02\x01\x06\x05+\x81\x04\x00\n\x03B\x00\x04N\x9a\xae\xd2G22"
+            b"\x82\xa6+\x18_W\xdfW9\xc4U\xc4 \x97e-9=\xa1\xb7\x0bQ\x97\x11"
+            b"sR\xadiR9\xa2\nu\xe4\xb6<\xc8\xb3\xe8\x01\x9d\x8e\x01\xc3"
+            b"\x0e\xb4\xa1t\xa2\xc8px\\4]\xb0{\x01\t\x00\x00\x00\x00\x00"
+            b"\x00\x00X0V0\x10\x06\x07*\x86H\xce=\x02\x01\x06\x05+\x81"
+            b"\x04\x00\n\x03B\x00\x04N\x9a\xae\xd2G22\x82\xa6+\x18_W\xdfW9\xc4"
+            b"U\xc4 \x97e-9=\xa1\xb7\x0bQ\x97\x11sR\xadiR9\xa2\nu\xe4"
+            b"\xb6<\xc8\xb3\xe8\x01\x9d\x8e\x01\xc3\x0e\xb4\xa1t\xa2\xc8px\\4"
+            b"]\xb0{"
+        )
+        t = Transaction.decode(encoded)
+
+        assert len(t.senders) == 2
+        assert t.senders[0].prev_tx_idx == t.senders[1].prev_tx_idx == 3
+        assert len(t.receivers) == 1
+        assert t.receivers[0].amount == 9
+
+        assert t.encode() == encoded
+        assert Transaction.decode(t.encode()) == t


### PR DESCRIPTION
## changes
- [x] rename `from_bytes` to `decode`
- [x] add `raw_decode`. [based off of `json.decode` and `json.raw_decode`](https://github.com/python/cpython/blob/045f205ba4710c4c633364a4e2e098483af936e5/Lib/json/decoder.py#L332-L356), where the former checks for a single object while `raw_decode` will parse until it finds an object and may have more data afterwards 
- [x] add `Transaction.decode` and `Transaction.raw_decode` 
- [x] add `Transaction. __eq__`
- [x] add `py.typed` file as per [PEP561](https://www.python.org/dev/peps/pep-0561/)